### PR TITLE
Add concise comments for spark 2.2

### DIFF
--- a/src/main/scala/io/phdata/retirementage/storage/HdfsStorage.scala
+++ b/src/main/scala/io/phdata/retirementage/storage/HdfsStorage.scala
@@ -108,8 +108,7 @@ trait HdfsStorage extends StorageActions with LazyLogging {
   }
 
   def getCurrentDatasetLocation(qualifiedTableName: String) = {
-    // Spark 2.2.0 implementation for Location
-    // Returns qualifiedTableName directory location using Spark 2.2 syntax
+    // spark2.2+ dataframe schema
     val details: DataFrame = spark.sql(s"describe extended $qualifiedTableName")
 
     details.filter(col("col_name") === "Location").select("data_type").collect().head.getString(0)


### PR DESCRIPTION
This commit will add concise comments for explaining spark 2.2 changes to read "describe extended" information about a dataframe