### PR TITLE
Feature/multiple join columns

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,3 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt-coursier" % "1.12")
 addSbtPlugin("io.phdata" % "sbt-os-detector" % "0.1.0-SNAPSHOT")
-

--- a/src/it/scala/io/phdata/retirementage/KuduObjects.scala
+++ b/src/it/scala/io/phdata/retirementage/KuduObjects.scala
@@ -4,8 +4,8 @@ import io.phdata.retirementage.domain.JoinOn
 import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
 
 object KuduObjects {
-  val defaultFactJoin = JoinOn("date", "date")
-  val defaultDimJoin  = JoinOn("id", "id")
+  val defaultFactJoin = List(JoinOn("date", "date"))
+  val defaultDimJoin  = List(JoinOn("id", "id"), JoinOn("date", "dim_date"))
 
   // Default fact objects
   val defaultFactSchema = StructType(StructField("date", LongType, nullable = false) :: Nil)
@@ -25,9 +25,14 @@ object KuduObjects {
 
   //Default sub-dimension objects
   val defaultSubSchema = StructType(
-    StructField("sub_id", StringType, nullable = false) :: StructField("id", StringType, nullable = false) :: Nil)
+    StructField("sub_id", StringType, nullable = false) ::
+      StructField("id", StringType, nullable = false) ::
+      StructField("dim_date", LongType, nullable = false) ::
+      Nil)
 
   val defaultSubKey: Seq[String] = Seq("sub_id")
 
-  val defaultSubData = List(List("10", "1"), List("20", "2"), List("30", "3"))
+  val defaultSubData = List(List("10", "1", TestObjects.today.getMillis / 1000),
+                            List("20", "2", TestObjects.today.minusYears(1).getMillis / 1000),
+                            List("30", "3", TestObjects.today.minusYears(2).getMillis / 1000))
 }

--- a/src/main/scala/io/phdata/retirementage/domain/ChildTable.scala
+++ b/src/main/scala/io/phdata/retirementage/domain/ChildTable.scala
@@ -18,7 +18,7 @@ package io.phdata.retirementage.domain
 
 case class ChildTable(name: String,
                       storage_type: String,
-                      join_on: JoinOn,
+                      join_on: List[JoinOn],
                       hold: Option[Hold],
                       child_tables: Option[List[ChildTable]])
     extends Table

--- a/src/test/scala/io/phdata/retirementage/ConfigParserTest.scala
+++ b/src/test/scala/io/phdata/retirementage/ConfigParserTest.scala
@@ -46,14 +46,16 @@ class ConfigParserTest extends FunSuite {
         |          - name: parquet2
         |            storage_type: parquet
         |            join_on:
-        |              parent: col1
-        |              self: col1
+        |              - parent: col1
+        |                self: col1
+        |              - parent: col2
+        |                self: col2
         |            child_tables:
         |              - name: parquet2
         |                storage_type: parquet
         |                join_on:
-        |                  parent: col1
-        |                  self: col1
+        |                  - parent: col1
+        |                    self: col1
         |      - name: customTable1
         |        storage_type: parquet
         |        filters:
@@ -86,10 +88,16 @@ class ConfigParserTest extends FunSuite {
                     ChildTable(
                       "parquet2",
                       "parquet",
-                      JoinOn("col1", "col1"),
+                      List(JoinOn("col1", "col1"), JoinOn("col2", "col2")),
                       None,
-                      Some(List(
-                        ChildTable("parquet2", "parquet", JoinOn("col1", "col1"), None, None))))
+                      Some(
+                        List(
+                          ChildTable("parquet2",
+                                     "parquet",
+                                     List(JoinOn("col1", "col1")),
+                                     None,
+                                     None)))
+                    )
                   )
                 )
               ),

--- a/src/test/scala/io/phdata/retirementage/filters/TableFilterTest.scala
+++ b/src/test/scala/io/phdata/retirementage/filters/TableFilterTest.scala
@@ -106,7 +106,8 @@ class TableFilterTest extends FunSuite with SparkTestBase {
     val parentTableName = writeTestTable(TestObjects.parentDataset, parentSchema)
     val childTableName  = writeTestTable(TestObjects.childDataset, childSchema)
 
-    val child = ChildTable(childTableName, "parquet", JoinOn("parentKey", "childKey"), None, None)
+    val child =
+      ChildTable(childTableName, "parquet", List(JoinOn("parentKey", "childKey")), None, None)
 
     val parent =
       DatedTable(parentTableName, "parquet", "date", 1, None, None, Some(List(child)))
@@ -134,7 +135,7 @@ class TableFilterTest extends FunSuite with SparkTestBase {
 
     val child = ChildTable(childTableName,
                            "parquet",
-                           JoinOn("parentKey", "childKey"),
+                           List(JoinOn("parentKey", "childKey")),
                            Some(Hold(true, "legal", "legal@client.biz")),
                            None)
 
@@ -161,7 +162,8 @@ class TableFilterTest extends FunSuite with SparkTestBase {
     val parentTableName = writeTestTable(TestObjects.parentDataset, parentSchema)
     val childTableName  = writeTestTable(TestObjects.childDataset, childSchema)
 
-    val child = ChildTable(childTableName, "parquet", JoinOn("parentKey", "childKey"), None, None)
+    val child =
+      ChildTable(childTableName, "parquet", List(JoinOn("parentKey", "childKey")), None, None)
 
     val table =
       DatedTable(parentTableName, "parquet", "date", 1, None, None, Some(List(child)))


### PR DESCRIPTION
Enhanced the ChildTable object to accept a collection of join relations instead of just one.

Also, changed the "inner" join type to "leftsemi" so that there will not be columns added to the DataFrame (which can cause "ambiguous column name" exceptions).  

Based on PR#12